### PR TITLE
Enhance domain controller setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This project aims to set up a Samba-based Active Directory Domain Controller on 
 - Scripts to bootstrap a new domain or join an existing Windows domain
 - Example configuration for replication between Linux and Windows
 - Placeholder GUI management tool integration
+- Basic time synchronization setup via chrony
 
 ## Getting Started
-Run `./setup.sh` on a fresh Linux machine. The script installs required packages, configures Kerberos and Samba, and optionally joins an existing domain.
+Run `./setup.sh` on a fresh Linux machine. The script installs required packages, configures Kerberos and Samba, sets up chrony for time synchronization, and optionally joins an existing domain.
 
 ## Disclaimer
 This repository contains high-level examples. Review and adapt the configuration to your environment. Testing in isolated labs is strongly recommended before production use.


### PR DESCRIPTION
## Summary
- install packages in a noninteractive mode
- add chrony and configure time sync
- write a basic smb.conf after provisioning or joining
- expose configuration steps in README

## Testing
- `shellcheck setup.sh tests/test_setup.sh`
- `bash tests/test_setup.sh`