### PR TITLE
Add cockpit integration with samba-ad-dc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This project aims to set up a Samba-based Active Directory Domain Controller on 
 - Samba 4 as the core domain controller
 - Scripts to bootstrap a new domain or join an existing Windows domain
 - Example configuration for replication between Linux and Windows
-- Placeholder GUI management tool integration
+- Optional Cockpit web GUI with `samba-ad-dc` module
 - Basic time synchronization setup via chrony
 
 ## Getting Started
-Run `./setup.sh` on a fresh Linux machine. The script installs required packages, configures Kerberos and Samba, sets up chrony for time synchronization, and optionally joins an existing domain.
+Run `./setup.sh` on a fresh Linux machine. The script installs the `samba-ad-dc` package, configures Kerberos and Samba, sets up chrony for time synchronization, and optionally joins an existing domain. Pass `--gui` to install Cockpit with the `samba-ad-dc` management module for a web-based administration interface.
 
 ## Disclaimer
 This repository contains high-level examples. Review and adapt the configuration to your environment. Testing in isolated labs is strongly recommended before production use.

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # setup.sh - configure a Samba Active Directory Domain Controller on Linux
-# This script installs Samba, configures Kerberos, and provisions or joins a domain.
+# This script installs the `samba-ad-dc` service, configures Kerberos and Samba,
+# and provisions or joins a domain.
 
 usage() {
     cat <<USAGE
@@ -11,7 +12,7 @@ Usage: $0 [--provision|--join DOMAIN] [--gui]
 Options:
   --provision           Provision a new domain (interactive)
   --join DOMAIN         Join an existing domain as an additional controller
-  --gui                 Install optional GUI management tools (Cockpit with addons)
+  --gui                 Install optional GUI management tools (Cockpit with 'samba-ad-dc' module)
 
 Run as root on a clean Linux server. The script is tested on Debian/Ubuntu.
 USAGE
@@ -31,7 +32,7 @@ install_packages() {
     echo "Installing required packages..."
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install -y samba smbclient krb5-user winbind \
+    apt-get install -y samba-ad-dc samba smbclient krb5-user winbind \
         bind9 dnsutils chrony
     unset DEBIAN_FRONTEND
 }
@@ -155,6 +156,6 @@ if [[ $GUI == "true" ]]; then
     install_gui
 fi
 
-systemctl restart smbd nmbd winbind || true
+systemctl enable --now samba-ad-dc || true
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- document optional Cockpit setup in README
- install `samba-ad-dc` and use its service in `setup.sh`
- make test script executable

## Testing
- `shellcheck setup.sh tests/test_setup.sh`
- `tests/test_setup.sh`
