### PR TITLE
Add config and Docker-based testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,15 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y shellcheck
+        sudo apt-get install -y shellcheck hadolint
     - name: ShellCheck
       run: |
         shellcheck setup.sh tests/test_setup.sh
+    - name: Lint Dockerfile
+      run: |
+        hadolint Dockerfile
     - name: Run tests
       run: |
-        chmod +x setup.sh tests/test_setup.sh
+        chmod +x setup.sh tests/test_setup.sh tests/test_dockerfile.sh
         bash tests/test_setup.sh
+        bash tests/test_dockerfile.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.deb
+config.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y samba-ad-dc samba smbclient krb5-user winbind \
+        bind9 dnsutils chrony && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY setup.sh /setup.sh
+COPY config.env.example /config.env
+
+RUN chmod +x /setup.sh && TEST_MODE=1 /setup.sh --provision
+
+CMD ["/usr/sbin/samba", "-F"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This project aims to set up a Samba-based Active Directory Domain Controller on 
 - Basic time synchronization setup via chrony
 
 ## Getting Started
+Copy `config.env.example` to `config.env` and adjust the variables for your environment.
 Run `./setup.sh` on a fresh Linux machine. The script installs the `samba-ad-dc` package, configures Kerberos and Samba, sets up chrony for time synchronization, and optionally joins an existing domain. Pass `--gui` to install Cockpit with the `samba-ad-dc` management module for a web-based administration interface.
+
+For containerized setups, build the provided `Dockerfile` which provisions a Samba AD DC image using the same script.
 
 ## Disclaimer
 This repository contains high-level examples. Review and adapt the configuration to your environment. Testing in isolated labs is strongly recommended before production use.

--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,4 @@
+# Example configuration for setup.sh
+DOMAIN=EXAMPLE
+REALM=EXAMPLE.COM
+ADMIN_PASS=Passw0rd!

--- a/tests/test_dockerfile.sh
+++ b/tests/test_dockerfile.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lint Dockerfile with hadolint if available
+if command -v hadolint >/dev/null; then
+    hadolint Dockerfile
+else
+    echo "hadolint not installed" >&2
+fi

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -5,3 +5,7 @@ set -euo pipefail
 bash -n ./setup.sh
 ./setup.sh --help >/tmp/setup_help.txt
 grep -q "Usage:" /tmp/setup_help.txt
+
+# Run the script in test mode to ensure code paths execute
+TEST_MODE=1 ./setup.sh --provision --realm TEST.REALM >/tmp/setup_out.txt
+grep -q "Setup complete." /tmp/setup_out.txt


### PR DESCRIPTION
## Summary
- add example configuration file and `.gitignore`
- load optional configuration in `setup.sh`
- support `TEST_MODE` in `setup.sh` for CI testing
- include Dockerfile to provision Samba AD DC
- extend tests and CI workflow to lint Dockerfile

## Testing
- `shellcheck setup.sh tests/test_setup.sh tests/test_dockerfile.sh`
- `tests/test_setup.sh && tests/test_dockerfile.sh`