### PR TITLE
Improve config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ This project aims to set up a Samba-based Active Directory Domain Controller on 
 - Basic time synchronization setup via chrony
 
 ## Getting Started
-Copy `config.env.example` to `config.env` and adjust the variables for your environment.
-Run `./setup.sh` on a fresh Linux machine. The script installs the `samba-ad-dc` package, configures Kerberos and Samba, sets up chrony for time synchronization, and optionally joins an existing domain. Pass `--gui` to install Cockpit with the `samba-ad-dc` management module for a web-based administration interface.
+Run `./setup.sh` on a fresh Linux machine. On first run the script will copy
+`config.env.example` to `config.env` if the file does not exist. Adjust the
+variables in `config.env` to match your environment. The script installs the
+`samba-ad-dc` package, configures Kerberos and Samba, sets up chrony for time
+synchronization, and optionally joins an existing domain. Pass `--gui` to
+install Cockpit with the `samba-ad-dc` management module for a web-based
+administration interface. If the `DOMAIN` variable is not set, it will be
+derived from the realm automatically.
 
 For containerized setups, build the provided `Dockerfile` which provisions a Samba AD DC image using the same script.
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 # Optional configuration file
 CONFIG_FILE="./config.env"
+EXAMPLE_CONFIG_FILE="./config.env.example"
 if [[ -f "$CONFIG_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$CONFIG_FILE"
+elif [[ -f "$EXAMPLE_CONFIG_FILE" ]]; then
+    echo "Config file $CONFIG_FILE not found. Creating from example." >&2
+    cp "$EXAMPLE_CONFIG_FILE" "$CONFIG_FILE"
     # shellcheck disable=SC1090
     source "$CONFIG_FILE"
 fi
@@ -178,6 +184,12 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Derive DOMAIN from REALM if not explicitly set
+if [[ -z "$DOMAIN" ]]; then
+    DOMAIN=$(echo "$REALM" | cut -d. -f1)
+    echo "DOMAIN not set; defaulting to $DOMAIN" >&2
+fi
 
 install_packages
 configure_kerberos


### PR DESCRIPTION
## Summary
- auto-create config file from example if missing
- default DOMAIN from REALM when not provided
- document new behavior in README

## Testing
- `bash tests/test_setup.sh`
- `bash tests/test_dockerfile.sh`