### PR TITLE
Warn if config.env uses defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ variables in `config.env` to match your environment. The script installs the
 synchronization, and optionally joins an existing domain. Pass `--gui` to
 install Cockpit with the `samba-ad-dc` management module for a web-based
 administration interface. If the `DOMAIN` variable is not set, it will be
-derived from the realm automatically.
+ derived from the realm automatically. If `config.env` still contains the
+ default values from `config.env.example`, the script prints a warning.
 
 For containerized setups, build the provided `Dockerfile` which provisions a Samba AD DC image using the same script.
 

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,13 @@ elif [[ -f "$EXAMPLE_CONFIG_FILE" ]]; then
     source "$CONFIG_FILE"
 fi
 
+# Warn if the configuration file still contains the defaults
+if [[ -f "$CONFIG_FILE" && -f "$EXAMPLE_CONFIG_FILE" ]]; then
+    if cmp -s "$CONFIG_FILE" "$EXAMPLE_CONFIG_FILE"; then
+        echo "WARNING: $CONFIG_FILE contains default values. Edit this file before running in production." >&2
+    fi
+fi
+
 # Enable reduced functionality when running in CI tests
 TEST_MODE=${TEST_MODE:-}
 

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 # Simple sanity test for setup.sh
 bash -n ./setup.sh
-./setup.sh --help >/tmp/setup_help.txt
+bash ./setup.sh --help >/tmp/setup_help.txt
 grep -q "Usage:" /tmp/setup_help.txt
 
 # Run the script in test mode to ensure code paths execute
-TEST_MODE=1 ./setup.sh --provision --realm TEST.REALM >/tmp/setup_out.txt
+TEST_MODE=1 bash ./setup.sh --provision --realm TEST.REALM >/tmp/setup_out.txt 2>/tmp/setup_err.txt
 grep -q "Setup complete." /tmp/setup_out.txt
+grep -q "default values" /tmp/setup_err.txt


### PR DESCRIPTION
## Summary
- detect if `config.env` matches `config.env.example`
- document the warning in the README
- ensure tests run the script via bash and check for the new warning

## Testing
- `bash tests/test_setup.sh && bash tests/test_dockerfile.sh`