### PR TITLE
Add client connection test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,18 @@ jobs:
         sudo apt-get install -y shellcheck hadolint
     - name: ShellCheck
       run: |
-        shellcheck setup.sh tests/test_setup.sh
+        shellcheck setup.sh client_test.sh client_container_test.sh \
+          tests/test_setup.sh tests/test_client_test.sh \
+          tests/test_client_container_test.sh
     - name: Lint Dockerfile
       run: |
         hadolint Dockerfile
     - name: Run tests
       run: |
-        chmod +x setup.sh tests/test_setup.sh tests/test_dockerfile.sh
+        chmod +x setup.sh client_test.sh client_container_test.sh \
+          tests/test_setup.sh tests/test_dockerfile.sh \
+          tests/test_client_test.sh tests/test_client_container_test.sh
         bash tests/test_setup.sh
         bash tests/test_dockerfile.sh
+        bash tests/test_client_test.sh
+        bash tests/test_client_container_test.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ derived from the realm automatically.
 
 For containerized setups, build the provided `Dockerfile` which provisions a Samba AD DC image using the same script.
 
+To verify connectivity from additional systems, use the `client_test.sh` script.
+Run it on a fresh machine with `--dc-ip` pointing to the domain controller and
+`--realm` set to your realm. The script installs necessary client packages and
+checks that shares are reachable via Kerberos authentication.
+Alternatively, `client_container_test.sh` launches a temporary Docker container
+running `client_test.sh` so you can verify access without provisioning a
+separate VM.
+
 ## Disclaimer
 This repository contains high-level examples. Review and adapt the configuration to your environment. Testing in isolated labs is strongly recommended before production use.
 

--- a/client_container_test.sh
+++ b/client_container_test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<USAGE
+Usage: $0 --dc-ip IP --realm REALM [--user USER --password PASS] [--image IMAGE]
+
+Launches a Docker container simulating a fresh client system and runs
+client_test.sh inside it to verify connectivity to the domain controller.
+USAGE
+}
+
+DC_IP=""
+REALM=""
+USER="Administrator"
+PASSWORD="Passw0rd!"
+IMAGE="ubuntu:24.04"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dc-ip)
+            DC_IP=$2
+            shift 2
+            ;;
+        --realm)
+            REALM=$2
+            shift 2
+            ;;
+        --user)
+            USER=$2
+            shift 2
+            ;;
+        --password)
+            PASSWORD=$2
+            shift 2
+            ;;
+        --image)
+            IMAGE=$2
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$DC_IP" || -z "$REALM" ]]; then
+    echo "--dc-ip and --realm are required" >&2
+    usage
+    exit 1
+fi
+
+CMD=("/opt/client_test.sh" --dc-ip "$DC_IP" --realm "$REALM" --user "$USER" --password "$PASSWORD")
+
+if [[ -n "${TEST_MODE:-}" ]]; then
+    echo "[TEST_MODE] Skipping docker container run"
+else
+    docker run --rm -v "$(pwd)":/opt -w /opt "$IMAGE" bash -c "${CMD[*]}"
+fi
+
+echo "Client Docker test completed successfully."

--- a/client_test.sh
+++ b/client_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<USAGE
+Usage: $0 --dc-ip IP --realm REALM [--user USER --password PASS]
+
+This script installs required packages and attempts to join a domain controller
+from a fresh system. It acquires a Kerberos ticket and lists available shares to
+verify connectivity.
+USAGE
+}
+
+DC_IP=""
+REALM=""
+USER="Administrator"
+PASSWORD="Passw0rd!"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dc-ip)
+            DC_IP=$2
+            shift 2
+            ;;
+        --realm)
+            REALM=$2
+            shift 2
+            ;;
+        --user)
+            USER=$2
+            shift 2
+            ;;
+        --password)
+            PASSWORD=$2
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$DC_IP" || -z "$REALM" ]]; then
+    echo "--dc-ip and --realm are required" >&2
+    usage
+    exit 1
+fi
+
+install_packages() {
+    if [[ -n "${TEST_MODE:-}" ]]; then
+        echo "[TEST_MODE] Skipping package installation"
+        return
+    fi
+    echo "Installing client packages..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y samba smbclient krb5-user winbind
+    unset DEBIAN_FRONTEND
+}
+
+configure_kerberos() {
+    if [[ -n "${TEST_MODE:-}" ]]; then
+        echo "[TEST_MODE] Skipping Kerberos configuration"
+        return
+    fi
+    cat >/etc/krb5.conf <<EOF_KRB
+[libdefaults]
+    default_realm = $REALM
+    dns_lookup_realm = false
+    dns_lookup_kdc = true
+EOF_KRB
+}
+
+obtain_ticket() {
+    if [[ -n "${TEST_MODE:-}" ]]; then
+        echo "[TEST_MODE] Skipping Kerberos ticket acquisition"
+        return
+    fi
+    echo "$PASSWORD" | kinit "${USER}@${REALM}"
+}
+
+test_connection() {
+    if [[ -n "${TEST_MODE:-}" ]]; then
+        echo "[TEST_MODE] Skipping connection test"
+        return
+    fi
+    smbclient -L "$DC_IP" -k || {
+        echo "Failed to list shares on $DC_IP" >&2
+        exit 1
+    }
+}
+
+install_packages
+configure_kerberos
+obtain_ticket
+test_connection
+
+echo "Client test script completed successfully."
+
+

--- a/tests/test_client_container_test.sh
+++ b/tests/test_client_container_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Basic sanity checks for client_container_test.sh
+bash -n ./client_container_test.sh
+TEST_MODE=1 ./client_container_test.sh --dc-ip 127.0.0.1 --realm TEST.REALM >/tmp/client_container.log
+grep -q "Client Docker test completed" /tmp/client_container.log

--- a/tests/test_client_test.sh
+++ b/tests/test_client_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Basic sanity checks for client_test.sh
+bash -n ./client_test.sh
+TEST_MODE=1 ./client_test.sh --dc-ip 127.0.0.1 --realm TEST.REALM >/tmp/client_test.txt
+grep -q "Client test script completed" /tmp/client_test.txt


### PR DESCRIPTION
## Summary
- add `client_test.sh` to verify client connectivity to the DC
- add `client_container_test.sh` to run client tests in Docker
- document the Docker-based client test in README
- extend CI with new script and tests

## Testing
- `shellcheck setup.sh client_test.sh client_container_test.sh tests/test_setup.sh tests/test_client_test.sh tests/test_client_container_test.sh`
- `bash tests/test_setup.sh && bash tests/test_dockerfile.sh && bash tests/test_client_test.sh && bash tests/test_client_container_test.sh`
