### PR TITLE
Add Keycloak support and Google IdP instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,16 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y shellcheck
+        sudo apt-get install -y shellcheck hadolint openjdk-17-jre-headless unzip
     - name: ShellCheck
       run: |
-        shellcheck setup.sh tests/test_setup.sh
+        shellcheck setup.sh keycloak_setup.sh tests/test_setup.sh tests/test_keycloak.sh
     - name: Lint Dockerfile
       run: |
         hadolint Dockerfile
     - name: Run tests
       run: |
-        chmod +x setup.sh tests/test_setup.sh tests/test_dockerfile.sh
+        chmod +x setup.sh keycloak_setup.sh tests/test_setup.sh tests/test_dockerfile.sh tests/test_keycloak.sh
         bash tests/test_setup.sh
         bash tests/test_dockerfile.sh
+        bash tests/test_keycloak.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.deb
 config.env
+keycloak-*.zip

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ administration interface. If the `DOMAIN` variable is not set, it will be
 
 For containerized setups, build the provided `Dockerfile` which provisions a Samba AD DC image using the same script.
 
+## Keycloak Integration
+`keycloak_setup.sh` installs Keycloak from the archived distribution included in
+this repository. The script can also print basic instructions for configuring
+Keycloak as a SAML identity provider for Google Workspace. Run `./keycloak_setup.sh --install` to extract Keycloak and `./keycloak_setup.sh --configure-google` to view the instructions.
+
 ## Disclaimer
 This repository contains high-level examples. Review and adapt the configuration to your environment. Testing in isolated labs is strongly recommended before production use.
 

--- a/keycloak_setup.sh
+++ b/keycloak_setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple Keycloak setup helper
+
+usage() {
+    cat <<USAGE
+Usage: $0 [--install] [--configure-google]
+
+Options:
+  --install           Install Keycloak from keycloak-26.2.4.zip
+  --configure-google  Output instructions to configure Keycloak as IdP for Google
+USAGE
+}
+
+if [[ ${1:-} == "--help" || $# -eq 0 ]]; then
+    usage
+    exit 0
+fi
+
+TEST_MODE=${TEST_MODE:-}
+INSTALL=false
+CONFIG_GOOGLE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --install)
+            INSTALL=true
+            ;;
+        --configure-google)
+            CONFIG_GOOGLE=true
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+install_keycloak() {
+    echo "Installing Keycloak..."
+    if [[ -n "$TEST_MODE" ]]; then
+        echo "[TEST_MODE] Skipping Keycloak installation"
+        return
+    fi
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y openjdk-17-jre-headless unzip
+    unset DEBIAN_FRONTEND
+
+    if [[ ! -f keycloak-26.2.4.zip ]]; then
+        echo "keycloak-26.2.4.zip not found" >&2
+        exit 1
+    fi
+
+    unzip -q keycloak-26.2.4.zip -d /opt
+    ln -sfn /opt/keycloak-26.2.4 /opt/keycloak
+    /opt/keycloak/bin/kc.sh build
+}
+
+configure_google() {
+    cat <<INFO
+To configure Keycloak as the IdP for Google Workspace:
+1. Log in to the Keycloak admin console.
+2. Create a new SAML client with:
+   Client ID: google
+   NameID Format: email
+   Client Signature Required: OFF
+   Valid Redirect URIs: https://www.google.com/a/<YOUR_DOMAIN>/acs
+3. Download the IdP metadata from:
+   https://<keycloak-host>/realms/master/protocol/saml/descriptor
+4. In the Google Admin console, set up a custom SAML app using the downloaded metadata.
+INFO
+}
+
+if $INSTALL; then
+    install_keycloak
+fi
+
+if $CONFIG_GOOGLE; then
+    configure_google
+fi
+
+if ! $INSTALL && ! $CONFIG_GOOGLE; then
+    usage
+    exit 1
+fi
+
+echo "Keycloak script complete."
+

--- a/tests/test_keycloak.sh
+++ b/tests/test_keycloak.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bash -n ./keycloak_setup.sh
+bash ./keycloak_setup.sh --help >/tmp/keycloak_help.txt
+grep -q "Usage:" /tmp/keycloak_help.txt
+TEST_MODE=1 bash ./keycloak_setup.sh --install >/tmp/keycloak_install.txt
+grep -q "Skipping Keycloak installation" /tmp/keycloak_install.txt
+TEST_MODE=1 bash ./keycloak_setup.sh --configure-google >/tmp/keycloak_google.txt
+grep -q "IdP for Google Workspace" /tmp/keycloak_google.txt
+


### PR DESCRIPTION
## Summary
- add a helper script to install Keycloak and show Google Workspace instructions
- integrate linting and tests for the script in CI
- keep Keycloak archives out of git
- fix argument parsing in keycloak setup

## Testing
- `bash tests/test_setup.sh`
- `bash tests/test_dockerfile.sh` *(shows `hadolint not installed`)*
- `bash tests/test_keycloak.sh`
